### PR TITLE
Add Ollama startup service

### DIFF
--- a/src/vs/platform/ollama/common/ollama.ts
+++ b/src/vs/platform/ollama/common/ollama.ts
@@ -1,0 +1,10 @@
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const IOllamaService = createDecorator<IOllamaService>('ollamaService');
+
+export interface IOllamaService {
+    readonly _serviceBrand: undefined;
+
+    start(): Promise<void>;
+    generate(prompt: string): Promise<string>;
+}

--- a/src/vs/platform/ollama/electron-browser/ollamaService.ts
+++ b/src/vs/platform/ollama/electron-browser/ollamaService.ts
@@ -1,0 +1,4 @@
+import { registerMainProcessRemoteService } from '../../ipc/electron-browser/services.js';
+import { IOllamaService } from '../common/ollama.js';
+
+registerMainProcessRemoteService(IOllamaService, 'ollama');

--- a/src/vs/platform/ollama/electron-main/ollamaService.ts
+++ b/src/vs/platform/ollama/electron-main/ollamaService.ts
@@ -1,0 +1,38 @@
+import { IOllamaService } from '../common/ollama.js';
+import { IRequestService, asTextOrError } from '../../request/common/request.js';
+import { ILogService } from '../../log/common/log.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
+
+export class NativeOllamaService implements IOllamaService {
+    declare readonly _serviceBrand: undefined;
+
+    constructor(
+        @IRequestService private readonly requestService: IRequestService,
+        @ILogService private readonly logService: ILogService
+    ) {}
+
+    async start(): Promise<void> {
+        try {
+            await this.requestService.request({ url: 'http://127.0.0.1:11434/api/tags' }, CancellationToken.None);
+            this.logService.info('[Ollama] service reachable');
+        } catch (err) {
+            this.logService.error('[Ollama] service not reachable', err);
+        }
+    }
+
+    async generate(prompt: string): Promise<string> {
+        try {
+            const context = await this.requestService.request({
+                type: 'POST',
+                url: 'http://127.0.0.1:11434/api/generate',
+                data: JSON.stringify({ model: 'llama2', prompt }),
+                headers: { 'Content-Type': 'application/json' }
+            }, CancellationToken.None);
+            const result = await asTextOrError(context);
+            return result ?? '';
+        } catch (err) {
+            this.logService.error('[Ollama] generate failed', err);
+            throw err;
+        }
+    }
+}

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -88,6 +88,7 @@ import './services/auxiliaryWindow/electron-browser/auxiliaryWindowService.js';
 import '../platform/extensionManagement/electron-browser/extensionsProfileScannerService.js';
 import '../platform/webContentExtractor/electron-browser/webContentExtractorService.js';
 import './services/process/electron-browser/processService.js';
+import '../platform/ollama/electron-browser/ollamaService.js';
 
 import { registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { IUserDataInitializationService, UserDataInitializationService } from './services/userData/browser/userDataInit.js';


### PR DESCRIPTION
## Summary
- add Ollama service interface
- implement Ollama service in electron main process
- register remote access for renderer
- wire up service during startup

## Testing
- `npm test`
- `npx gulp vscode-darwin-x64-min` *(fails: needs gulp package)*

------
https://chatgpt.com/codex/tasks/task_e_684f3f1db3d8832d895810aee9dda9c5